### PR TITLE
Refactoring and Fixing 3 Issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,21 +25,33 @@ You will also need to make sure you fix all linting errors.
 
 ## Convars
 ``wa_enable``  
-Allows you to disable WebAudio for your server or for the client.
+**SHARED** Convar that allows you to disable WebAudio for yourself or for the server. If set to 0, also purges any running streams.
 
 ``wa_admin_only``  
-Serverside convar that allows you to set WebAudio E2 access to only Admins or Only SuperAdmins. (0 for Everyone, 1 for Admins, 2 for SuperAdmins)
-
-``wa_volume_max``  
-Serverside convar that allows you to set the maximum volume a WebAudio stream can play at. 200 is 200%, 50 is 50%, etc.
+**SERVER** Convar that allows you to set WebAudio E2 access to only Admins or Only SuperAdmins. (0 for Everyone, 1 for Admins, 2 for SuperAdmins)
 
 ``wa_stream_max``  
-Serverside convar that allows you to set the maximum volume a WebAudio streams a player can own at once.
+**SERVER** convar that allows you to set the maximum volume a WebAudio streams a player can own at once.
+
+``wa_volume_max``  
+**SHARED** Convar that allows you to set the maximum volume a WebAudio stream can play at. 200 is 200%, 50 is 50%, etc. Can set it for yourself to clamp any future streams to.
+
+``wa_radius_max``  
+**SHARED** Convar that allows you to set the maximum distance a stream can be heard from. Works on your client.
+
+## Concommands
+
+``wa_purge``
+**CLIENT** Concommand that purges all currently running streams and makes sure you don't get any useless net messages from them.
+
+``wa_reload_whitelist``
+**SHARED** Concommand that tries to reload your whitelist at ``data/webaudio_whitelist.txt``
 
 ## Functions
 
 ``webaudio webAudio(string url)``  
-Returns a WebAudio object of that URL as long as it is whitelisted by the server. Has a 150 ms cooldown between calls. If you can't create a webAudio object, will error, so check webAudioCanCreate before calling this!
+Returns a **WebAudio** object of that URL as long as it is whitelisted by the server.  
+Has a 150 ms cooldown between calls. If you can't create a webAudio object, will error, so check ``webAudioCanCreate`` before calling this!
 
 ``number webAudiosLeft()``  
 Returns how many WebAudios you can create.
@@ -48,7 +60,7 @@ Returns how many WebAudios you can create.
 Returns whether you can create a webaudio stream. Checks cooldown and whether you have a slot for another stream left.
 
 ``number webAudioCanCreate(string url)``  
-Same as webAudioCanCreate(), but also checks if the url given is whitelisted so you don't error on webAudio calls.
+Same as ``webAudioCanCreate()``, but also checks if the url given is whitelisted so you don't error on webAudio calls.
 
 ``number webAudioEnabled()``  
 Returns whether webAudio is enabled for use on the server.
@@ -99,3 +111,7 @@ Alias of webaudio:setParent(e) Parents the stream position to e, local to the en
 
 ``void webaudio:unparent()``  
 Alias of webaudio:setParent(), Unparents the stream from the currently parented entity. Does not update the object.
+
+``void webaudio:setRadius(number radius)``  
+Sets the radius in which to the stream will be heard in. Default is 200 and (default) max is 1500. Does not update the object.
+

--- a/STEAM_README.txt
+++ b/STEAM_README.txt
@@ -15,28 +15,59 @@ This is a list of console variables that you can change to configure the addon t
 
 [table]
 [tr]
-	[th]Variable Name[/th]
+	[th]ConVar Name[/th]
 	[th]Description[/th]
+	[th]Realm[/th]
 [/tr]
 [tr]
 	[td]wa_enable[/td]
 	[td]Shared convar that allows you to disable WebAudio for the server or yourself depending on whether it is executed in the client or server console[/td]
+	[td]SHARED[/td]
 [/tr]
 [tr]
 	[td]wa_admin_only[/td]
-	[td]Serverside convar that allows you to set WebAudio E2 access to only Admins or Only Super Admins. (0 for Everyone, 1 for Admins, 2 for Super Admins).[/td]
+	[td]Allows you to set WebAudio E2 access to only Admins or Only Super Admins. (0 for Everyone, 1 for Admins, 2 for Super Admins).[/td]
+	[td]SERVER[/td]
 [/tr]
 [tr]
 	[td]wa_volume_max[/td]
 	[td]
-		Serverside convar that allows you to set the maximum volume a WebAudio stream can play at.
+		Shared convar that allows you to set the maximum volume a WebAudio stream can play at.
 		100 is 100%, 50 is 50% and so on.
 		Helps to prevent nasty earrape music being played too loudly
 	[/td]
+	[td]SHARED[/td]
 [/tr]
 [tr]
 	[td]wa_stream_max[/td]
 	[td]Serverside convar that allows you to set the max amount of streams a player can have at once[/td]
+	[td]SERVER[/td]
+[/tr]
+[tr]
+	[td]wa_radius_max[/td]
+	[td]Allows you to set the maximum distance a stream can be heard from. Works on your client.[/td]
+	[td]SHARED[/td]
+[/tr]
+[/table]
+
+[h2]Console Commands[/h2]
+This is a list of Concommands to use with this addon as a server owner and a user.
+
+[table]
+[tr]
+	[th]ConCommand Name[/th]
+	[th]Description[/th]
+	[th]Realm[/th]
+[/tr]
+[tr]
+	[td]wa_purge[/td]
+	[td]Purges all currently running streams and makes sure you don't get any useless net messages from them.[/td]
+	[td]CLIENT[/td]
+[/tr]
+[tr]
+	[td]wa_reload_whitelist[/td]
+	[td]Reloads your whitelist at data/webaudio_whitelist.txt[/td]
+	[td]SHARED[/td]
 [/tr]
 [/table]
 
@@ -179,6 +210,17 @@ This is a list of console variables that you can change to configure the addon t
 	[td]void webaudio:unparent()[/td]
 	[td]
 		[b]Alias[/b] of webaudio:setParent() when the entity field is left blank.
+	[/td]
+	[td] ❌ [/td]
+[/tr]
+[tr]
+	[td]void webaudio:setRadius(number radius)[/td]
+	[td]
+		Sets the radius in which to the stream will be heard in.
+		Default is 200 and (default) max is 1500.
+
+		This isn't perfect, people can still play somewhat loud sounds and go past the radius!
+		If this is the case, use the convar [b]wa_radius_max[/b] to change it for your client.
 	[/td]
 	[td] ❌ [/td]
 [/tr]

--- a/lua/autorun/client/wa_receiver.lua
+++ b/lua/autorun/client/wa_receiver.lua
@@ -4,8 +4,8 @@ local Common = include("autorun/wa_common.lua")
 local warn, notify = Common.warn, Common.notify
 
 -- Convars
-local Enabled, AdminOnly = Common.WAEnabled, Common.WAAdminOnly, Common.WAMaxStreamsPerUser
-local MaxVolume, MaxRadius = Common.WAMaxVolume, Common.WAMaxRadius
+local Enabled = Common.WAEnabled
+local MaxRadius = Common.WAMaxRadius
 
 local WebAudios, WebAudioCounter = {}, 0
 local AwaitingChanges = {}

--- a/lua/autorun/client/wa_receiver.lua
+++ b/lua/autorun/client/wa_receiver.lua
@@ -2,59 +2,52 @@
 
 local Common = include("autorun/wa_common.lua")
 local warn, notify = Common.warn, Common.notify
-local Enabled = Common.WAEnabled
 
-local Audios, AwaitingChanges = {}, {}
+-- Convars
+local Enabled, AdminOnly = Common.WAEnabled, Common.WAAdminOnly, Common.WAMaxStreamsPerUser
+local MaxVolume, MaxRadius = Common.WAMaxVolume, Common.WAMaxRadius
+
+local WebAudios, WebAudioCounter = {}, 0
+local AwaitingChanges = {}
 
 local updateObject -- To be declared below
 
-local function createObject(_, id, url, owner, bass)
-    local self = setmetatable({}, WebAudio)
-    -- Mutable
-    self.volume = 1
-    self.time = 0
-    self.pos = nil -- Start as nil for parenting to work.
-    self.playing = false
-    self.playback_rate = 1
-    self.modified = 0
-    self.destroyed = false
-    self.direction = Vector()
-    -- Mutable
+local WebAudio = WebAudio
 
-    self.id = id
-    self.url = url
-    self.owner = owner
-
-    -- Receiver Only
-    self.bass = bass
-    self.parent_pos = Vector()
-    -- Receiver Only
-
-    return self
+--- Creates a WebAudio receiver and returns it.
+-- @param number id ID of the serverside WebAudio object to receive from.
+-- @param string url URL to play from the stream
+-- @param Entity owner Owner of the stream for tracking purposes & future blocking/purging.
+local function registerStream(id, url, owner)
+    WebAudios[id] = WebAudio(id, url, owner)
+    WebAudioCounter = WebAudioCounter + 1
 end
 
 net.Receive("wa_create", function(len)
-    local id, url, flags, owner = net.ReadUInt(8), net.ReadString(), net.ReadString(), net.ReadEntity()
+    local id, url, owner = WebAudio:readID(), net.ReadString(), net.ReadEntity()
 
     if not Enabled:GetBool() then
+        -- Shouldn't happen anymore
         notify("%s(%d) attempted to create a WebAudio object with url [\"%s\"], but you have WebAudio disabled!", owner:Nick(), owner:SteamID64(), url)
         return
     end
 
     if WebAudio:isWhitelistedURL(url) then
         notify("User %s(%d) created WebAudio object with url [\"%s\"]", owner:Nick(), owner:SteamID64(), url)
-        sound.PlayURL(url, flags, function(bass, errid, errname)
+        sound.PlayURL(url, "3d noblock noplay", function(bass, errid, errname)
             if not errid then
-                Audios[id].bass = bass
+                WebAudios[id].bass = bass
 
                 local changes_awaiting = AwaitingChanges[id]
                 if changes_awaiting then
                     updateObject(id, changes_awaiting, true, false)
                     AwaitingChanges[id] = nil
                 end
+            else
+                warn("Error when creating WebAudio receiver with id %d, Error [%s]", id, errname)
             end
         end)
-        Audios[id] = WebAudio(id, url, owner)
+        registerStream(id, url, owner)
     else
         warn("User %s(%d) tried to create unwhitelisted WebAudio object with url [\"%s\"]", owner, owner:SteamID64(), url)
     end
@@ -64,21 +57,22 @@ local Modify = Common.Modify
 local hasModifyFlag = Common.hasModifyFlag
 
 --- Stores changes on the Receiver object
--- @param number id ID of the Receiver Object, to be used to search the table of 'Audios'
+-- @param number id ID of the Receiver Object, to be used to search the table of 'WebAudios'
 -- @param number modify_enum Mixed bitwise enum that will be sent by the server to determine what changed in an object to avoid wasting a lot of bits for every piece of information.
 -- @param boolean handle_bass Whether this object has a 'bass' object. If so, we can just immediately apply the changes to the object.
 -- @param boolean inside_net Whether this function is inside the net message that contains the new information. If not, we're most likely just applying object changes to the receiver after waiting for the IGmodAudioChannel object to be created.
 function updateObject(id, modify_enum, handle_bass, inside_net)
     -- Object destroyed
-    local self = Audios[id]
+    local self = WebAudios[id]
     local bass = self.bass
 
+    -- Keep in mind that the order of these needs to sync with wa_interface's reading order.
     if hasModifyFlag(modify_enum, Modify.destroyed) then
         self.destroyed = true
         if handle_bass then
             timer.Remove("wa_parent_" .. self.id) -- Parent timer
             bass:Stop()
-            Audios[ self.id ] = nil
+            WebAudios[ self.id ] = nil
             self = nil
         end
         return
@@ -90,7 +84,7 @@ function updateObject(id, modify_enum, handle_bass, inside_net)
         if handle_bass then bass:SetVolume(self.volume) end
     end
 
-    -- Time changed
+    -- Playback time changed
     if hasModifyFlag(modify_enum, Modify.time) then
         if inside_net then self.time = net.ReadUInt(16) end
         if handle_bass then
@@ -106,6 +100,14 @@ function updateObject(id, modify_enum, handle_bass, inside_net)
         end
     end
 
+    -- Direction changed.
+    if hasModifyFlag(modify_enum, Modify.direction) then
+        if inside_net then self.direction = net.ReadVector() end
+        if handle_bass then
+            bass:SetPos(self.pos, self.direction)
+        end
+    end
+
     -- Playback rate changed
     if hasModifyFlag(modify_enum, Modify.playback_rate) then
         if inside_net then self.playback_rate = net.ReadFloat() end
@@ -114,29 +116,15 @@ function updateObject(id, modify_enum, handle_bass, inside_net)
         end
     end
 
-    -- Direction changed.
-    if hasModifyFlag(modify_enum, Modify.direction) then
-        if inside_net then self.direction = net.ReadVector() end
-        -- Should always be true so..
+    -- Radius changed
+    if hasModifyFlag(modify_enum, Modify.radius) then
+        if inside_net then self.radius = math.min(net.ReadUInt(16), MaxRadius:GetInt()) end
         if handle_bass then
-            bass:SetPos(self.pos, self.direction)
+            bass:Set3DFadeDistance(self.radius, 1000000000)
         end
     end
 
-    -- Playing / Paused state changed
-    if hasModifyFlag(modify_enum, Modify.playing) then
-        if inside_net then self.playing = net.ReadBool() end
-        -- Should always be true so..
-        if handle_bass then
-            if self.playing then
-                -- If changed to be playing, play. Else stop
-                bass:Play()
-            else
-                bass:Pause()
-            end
-        end
-    end
-
+    -- Was parented or unparented
     if hasModifyFlag(modify_enum, Modify.parented) then
         if inside_net then
             self.parented = net.ReadBool()
@@ -171,14 +159,28 @@ function updateObject(id, modify_enum, handle_bass, inside_net)
             end)
         end
     end
+
+    -- Playing / Paused state changed. Should always be at the bottom here
+    if hasModifyFlag(modify_enum, Modify.playing) then
+        if inside_net then self.playing = net.ReadBool() end
+        -- Should always be true so..
+        if handle_bass then
+            if self.playing then
+                -- If changed to be playing, play. Else pause
+                bass:Play()
+            else
+                bass:Pause()
+            end
+        end
+    end
 end
 
 net.Receive("wa_change", function(len)
-    local id, modify_enum = net.ReadUInt(8), net.ReadUInt(8)
-    local obj = Audios[id]
+    local id, modify_enum = WebAudio:readID(), WebAudio:readModify()
+    local obj = WebAudios[id]
 
     if AwaitingChanges[id] then return end
-    if not obj then return end -- Hm..
+    if not obj then return end -- Object was destroyed on the client for whatever reason. Most likely reason is wa_purge
 
     if obj.bass then
         -- Store and handle changes
@@ -190,5 +192,96 @@ net.Receive("wa_change", function(len)
     end
 end)
 
+--- Destroys a stream and stops the underlying IGmodAudioChannel
+-- @param number id ID of the stream to destroy
+local function destroyStream(id)
+    local stream = WebAudios[id]
+    if stream then
+        local bass = stream.bass
+        if bass and bass:IsValid() then
+            bass:Stop()
+        end
+        WebAudios[id] = nil
+    end
+end
+
+--- Stops every currently existing stream
+-- @param boolean write_ids Whether to net write IDs or not while looping through the streams. Used for wa_ignore.
+local function stopStreams(write_ids)
+    for id, stream in pairs(WebAudios) do
+        if stream then
+            destroyStream(id)
+            if write_ids then
+                -- If we are in wa_purge
+                WebAudio:writeID(id)
+            end
+            WebAudios[id] = nil
+        end
+    end
+end
+
+concommand.Add("wa_purge", function()
+    if WebAudioCounter == 0 then return end
+    net.Start("wa_ignore", true)
+        net.WriteUInt(WebAudioCounter, 8)
+        stopStreams(true)
+    net.SendToServer()
+end, nil, "Purges all of the currently playing WebAudio streams")
+
+--- When the client toggles wa_enable send this info to the server to stop sending net messages to them.
+cvars.AddChangeCallback("wa_enable", function(convar, old, new)
+    local enabled = new ~= "0"
+    if not enabled then
+        stopStreams(false)
+    end
+    net.Start("wa_enable", true)
+        net.WriteBool(enabled) -- Tell the server we're
+    net.SendToServer()
+end)
+
+local function createObject(_, id, url, owner, bass)
+    local self = setmetatable({}, WebAudio)
+    -- Mutable
+    self.playing = false
+    self.destroyed = false
+
+    self.parented = false
+    self.parent = nil -- Entity
+
+    self.modified = 0
+
+    self.playback_rate = 1
+    self.volume = 1
+    self.time = 0
+    self.radius = math.min(200, MaxRadius:GetInt()) -- 200 by default or client's max radius if it's lower
+
+    self.pos = Vector()
+    self.direction = Vector()
+    -- Mutable
+
+    self.id = id
+    self.url = url
+    self.owner = owner
+
+    -- Receiver Only
+    self.bass = bass
+    self.parent_pos = Vector() -- Local position to parent when it was initially parented.
+    -- Receiver Only
+
+    return self
+end
+
 local WA_STATIC_META = getmetatable(WebAudio)
 WA_STATIC_META.__call = createObject
+
+--- Returns the list of all WebAudio receivers.
+-- @return table WebAudios
+function WA_STATIC_META:getList()
+    return WebAudios
+end
+
+--- Returns a WebAudio receiver struct from an id if there is one with that id.
+-- @return WebAudio Struct
+function WA_STATIC_META:getFromID(id)
+    return WebAudios[id]
+end

--- a/lua/autorun/wa_init.lua
+++ b/lua/autorun/wa_init.lua
@@ -22,6 +22,32 @@ function WebAudioStatic:getNULL()
     return setmetatable({ destroyed = true }, WebAudio)
 end
 
+-- We have these functions so that maybe we can change the number of bits if we make a convar for the global number of WebAudios. Just a thought.
+
+--- Same as net.ReadUInt but doesn't need the bit length in order to adapt our code more easily.
+-- @return number UInt8
+function WebAudioStatic:readID()
+    return net.ReadUInt(9)
+end
+
+--- Same as net.WriteUInt but doesn't need the bit length in order to adapt our code more easily.
+-- @param number id ID to write in the net message
+function WebAudioStatic:writeID(id)
+    net.WriteUInt(id, 9)
+end
+
+--- Reads a WebAudio Modify enum
+-- @return number UInt16
+function WebAudioStatic:readModify()
+    return net.ReadUInt(16)
+end
+
+--- Writes a WebAudio Modify enum
+-- @param number UInt16
+function WebAudioStatic:writeModify(modify)
+    net.WriteUInt(modify, 16)
+end
+
 
 WebAudioStatic.instanceOf = isWebAudio
 WebAudioStatic.isWebAudio = isWebAudio

--- a/lua/entities/gmod_wire_expression2/core/custom/cl_webaudio.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/cl_webaudio.lua
@@ -31,6 +31,7 @@ desc("isParented(xwa:)", "Returns 1 or 0 for whether the webaudio object is pare
 desc("isValid(xwa:)", "Returns 1 or 0 for whether the webaudio object is valid (If it is not destroyed & Not invalid from quota)")
 desc("setParent(xwa:e)", "Parents the stream position to e, local to the entity. If you've never set the position before, will be parented to the center of the prop. Returns 1 if successfully parented or 0 if prop wasn't valid")
 desc("setParent(xwa:)", "Unparents the stream")
+desc("setRadius(xwa:n)", "Sets the radius in which to the stream will be heard in. Default is 200 and (default) max is 1500.")
 
 desc("unparent(xwa:)", "Alias of xwa:setParent(), Unparents the stream")
 desc("parentTo(xwa:e)", "Alias of xwa:setParent(), Parents the stream to entity e")


### PR DESCRIPTION
* Added wa_purge. Instantly kills and stops receiving data from every currently running stream on your client.
* Added setRadius, allows you to set the radius in which the stream can be heard from.
* wa_enable now has the same functionality as doing wa_purge if you set it to 0, no longer receiving any net messages from currently running streams and any future streams until you reenable it.

Along side this comes the convar:
* wa_radius_max

* On the lua (api) side, added static methods to streamline the stuff going on in the code. You should check out all of the new methods.

Fixes #3
Fixes #4
Fixes #6

Will bump us to v0.1.4