### PR TITLE
Change handling of webaudio radius & volume

### DIFF
--- a/lua/autorun/client/wa_receiver.lua
+++ b/lua/autorun/client/wa_receiver.lua
@@ -16,7 +16,7 @@ local updateObject -- To be declared below
 
 local WebAudio = WebAudio
 
-timer.Create("wa_think", 200/1000, 0, function()
+timer.Create("wa_think", 200 / 1000, 0, function()
     local player_pos = LocalPlayer():GetPos()
     for id, stream in pairs(WebAudios) do
         local bass = stream.bass
@@ -31,7 +31,7 @@ timer.Create("wa_think", 200/1000, 0, function()
 
             -- Manually handle volume as you go farther from the stream.
             local dist_to_stream = player_pos:Distance( stream.pos )
-            bass:SetVolume( stream.volume * ( 1 - math_min(dist_to_stream/stream.radius, 1) ) )
+            bass:SetVolume( stream.volume * ( 1 - math_min(dist_to_stream / stream.radius, 1) ) )
         end
     end
 end)
@@ -101,7 +101,7 @@ function updateObject(id, modify_enum, handle_bass, inside_net)
 
     -- Volume changed
     if hasModifyFlag(modify_enum, Modify.volume) then
-        if inside_net then self.volume = math_min(net.ReadFloat(), MaxVolume:GetInt()/100) end
+        if inside_net then self.volume = math_min(net.ReadFloat(), MaxVolume:GetInt() / 100) end
         if handle_bass then bass:SetVolume(self.volume) end
     end
 

--- a/lua/autorun/client/wa_receiver.lua
+++ b/lua/autorun/client/wa_receiver.lua
@@ -25,9 +25,8 @@ timer.Create("wa_think", 200 / 1000, 0, function()
         local bass = stream.bass
         if bass then
             -- Handle Parenting
-            local parent = stream.parent
+            local parent, parent_pos = stream.parent, stream.parent_pos
             if parent and parent ~= NULL then
-                local parent, parent_pos = stream.parent, stream.parent_pos
                 local position = parent_pos and parent:LocalToWorld(parent_pos) or parent:GetPos()
                 bass:SetPos( position )
                 stream.pos = position
@@ -174,11 +173,11 @@ function updateObject(id, modify_enum, handle_bass, inside_net)
         end
 
         if handle_bass and self.parented then
-            local parent = self.parent
+            local parent, parent_pos = self.parent, self.parent_pos
             if parent and parent ~= NULL then
-                local parent, parent_pos = self.parent, self.parent_pos
                 local position = parent_pos and parent:LocalToWorld(parent_pos) or parent:GetPos()
                 bass:SetPos( position )
+                self.pos = position
             end
         end
     end

--- a/lua/autorun/client/wa_receiver.lua
+++ b/lua/autorun/client/wa_receiver.lua
@@ -142,7 +142,7 @@ function updateObject(id, modify_enum, handle_bass, inside_net)
         if inside_net then self.radius = math_min(net.ReadUInt(16), MaxRadius:GetInt()) end
         if handle_bass then
             local dist_to_stream = LocalPlayer():GetPos():Distance( self.pos )
-            bass:SetVolume( self.volume * ( 1 - math_min(dist_to_stream/self.radius, 1) ) )
+            bass:SetVolume( self.volume * ( 1 - math_min(dist_to_stream / self.radius, 1) ) )
         end
     end
 

--- a/lua/autorun/client/wa_receiver.lua
+++ b/lua/autorun/client/wa_receiver.lua
@@ -33,8 +33,10 @@ timer.Create("wa_think", 200 / 1000, 0, function()
             end
 
             -- Manually handle volume as you go farther from the stream.
-            local dist_to_stream = player_pos:Distance( stream.pos )
-            bass:SetVolume( stream.volume * ( 1 - math_min(dist_to_stream / stream.radius, 1) ) )
+            if stream.pos then
+                local dist_to_stream = player_pos:Distance( stream.pos )
+                bass:SetVolume( stream.volume * ( 1 - math_min(dist_to_stream / stream.radius, 1) ) )
+            end
         end
     end
 end)
@@ -145,7 +147,7 @@ function updateObject(id, modify_enum, handle_bass, inside_net)
     -- Radius changed
     if hasModifyFlag(modify_enum, Modify.radius) then
         if inside_net then self.radius = math_min(net.ReadUInt(16), MaxRadius:GetInt()) end
-        if handle_bass then
+        if handle_bass and self.pos then
             local dist_to_stream = LocalPlayer():GetPos():Distance( self.pos )
             bass:SetVolume( self.volume * ( 1 - math_min(dist_to_stream / self.radius, 1) ) )
         end

--- a/lua/autorun/client/wa_receiver.lua
+++ b/lua/autorun/client/wa_receiver.lua
@@ -17,7 +17,10 @@ local updateObject -- To be declared below
 local WebAudio = WebAudio
 
 timer.Create("wa_think", 200 / 1000, 0, function()
-    local player_pos = LocalPlayer():GetPos()
+    local LocalPlayer = LocalPlayer()
+    if not LocalPlayer or LocalPlayer == NULL then return end
+
+    local player_pos = LocalPlayer:GetPos()
     for id, stream in pairs(WebAudios) do
         local bass = stream.bass
         if bass then
@@ -102,7 +105,9 @@ function updateObject(id, modify_enum, handle_bass, inside_net)
     -- Volume changed
     if hasModifyFlag(modify_enum, Modify.volume) then
         if inside_net then self.volume = math_min(net.ReadFloat(), MaxVolume:GetInt() / 100) end
-        if handle_bass then bass:SetVolume(self.volume) end
+        if handle_bass then
+            bass:SetVolume(self.volume)
+        end
     end
 
     -- Playback time changed
@@ -268,7 +273,7 @@ local function createObject(_, id, url, owner, bass)
     self.time = 0
     self.radius = math_min(200, MaxRadius:GetInt()) -- 200 by default or client's max radius if it's lower
 
-    self.pos = Vector()
+    self.pos = nil -- Needs to be nil to know whether to set to the parent's position with setParent.
     self.direction = Vector()
     -- Mutable
 

--- a/lua/autorun/client/wa_receiver.lua
+++ b/lua/autorun/client/wa_receiver.lua
@@ -27,9 +27,10 @@ timer.Create("wa_think", 200 / 1000, 0, function()
             -- Handle Parenting
             local parent = stream.parent
             if parent and parent ~= NULL then
-                local pos = parent:LocalToWorld(stream.parent_pos)
-                bass:SetPos( pos )
-                stream.pos = pos
+                local parent, parent_pos = stream.parent, stream.parent_pos
+                local position = parent_pos and parent:LocalToWorld(parent_pos) or parent:GetPos()
+                bass:SetPos( position )
+                stream.pos = position
             end
 
             -- Manually handle volume as you go farther from the stream.
@@ -165,7 +166,7 @@ function updateObject(id, modify_enum, handle_bass, inside_net)
                     self.parent_pos = ent:WorldToLocal(self.pos)
                 else
                     -- self.pos hasn't been touched, play the sound at the entity's position.
-                    self.parent_pos = Vector()
+                    self.parent_pos = nil
                 end
             else
                 self.parent = nil
@@ -175,7 +176,9 @@ function updateObject(id, modify_enum, handle_bass, inside_net)
         if handle_bass and self.parented then
             local parent = self.parent
             if parent and parent ~= NULL then
-                bass:SetPos( self.parent:LocalToWorld(self.parent_pos) )
+                local parent, parent_pos = self.parent, self.parent_pos
+                local position = parent_pos and parent:LocalToWorld(parent_pos) or parent:GetPos()
+                bass:SetPos( position )
             end
         end
     end

--- a/lua/autorun/wa_common.lua
+++ b/lua/autorun/wa_common.lua
@@ -6,8 +6,8 @@ local WAMaxStreamsPerUser = CreateConVar("wa_stream_max", "5", FCVAR_REPLICATED,
 -- SHARED Convars
 local WAEnabled = CreateConVar("wa_enable", "1", FCVAR_ARCHIVE + FCVAR_USERINFO, "Whether webaudio should be enabled to play on your client/server or not.", 0, 1)
 -- TODO: When we add selective targets maybe allow use of WebAudios at higher configs but only send it to clients that allow this.
-local WAMaxVolume = CreateConVar("wa_volume_max", "200", FCVAR_ARCHIVE, "Highest volume a webaudio sound can be played at, in percentage. 200 is 200%. SHARED Convar", 0)
-local WAMaxRadius = CreateConVar("wa_radius_max", "1500", FCVAR_ARCHIVE, "Farthest distance a WebAudio stream can be heard from. Will clamp to this value. SHARED Convar", 0)
+local WAMaxVolume = CreateConVar("wa_volume_max", "300", FCVAR_ARCHIVE, "Highest volume a webaudio sound can be played at, in percentage. 200 is 200%. SHARED Convar", 0)
+local WAMaxRadius = CreateConVar("wa_radius_max", "10000", FCVAR_ARCHIVE, "Farthest distance a WebAudio stream can be heard from. Will clamp to this value. SHARED Convar", 0)
 
 -- Note that none of these convars affect the Lua Api on the SERVER. On the client they may however if they are aren't FCVAR_REPLICATED
 


### PR DESCRIPTION
Fixes #13, also made the maximum radius and volume settings much more relaxed at 3x volume and 10,000 source units distance radius. If you want it lower, just set your server or client's convars.