### PR TITLE
Fix attempting to call IsValid from a possibly nil object

### DIFF
--- a/lua/entities/gmod_wire_expression2/core/custom/webaudio.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/webaudio.lua
@@ -225,7 +225,7 @@ end
 
 __e2setcost(4)
 e2function number webaudio:isValid()
-    return this:IsValid() and 1 or 0
+    return IsValid(this) and 1 or 0
 end
 
 __e2setcost(2)


### PR DESCRIPTION
* Use `IsValid(this)` instead of `this:IsValid()` when calling `webaudio:isValid()`. Otherwise, say we want to check if we created a webaudio previously and want to delete it before creating a new one, like on this snippet:

```
@persist WA_TTS:webaudio

...

if (WA_TTS:isValid()) {
    WA_TTS:destroy()
}

WA_TTS = webAudio("...")
WA_TTS:setParent(entity())
WA_TTS:play()
```

Will throw this error:

`sv: Expression 2 (generic): entities/gmod_wire_expression2/core/custom/webaudio.lua:228: attempt to index local 'this' (a nil value)`
