### PR TITLE
Additions to the default whitelist

### DIFF
--- a/lua/autorun/webaudio.lua
+++ b/lua/autorun/webaudio.lua
@@ -523,6 +523,12 @@ local registers = { ["pattern"] = pattern, ["simple"] = simple }
 local Whitelist = {
 	-- Soundcloud
 	pattern [[[%w-_]+%.sndcdn%.com/.+]],
+	
+	-- Bandcamp
+	pattern [[[%w-_]+%.bcbits%.com/.+]]
+	
+	-- Google Video (used by Youtube)
+	pattern [[[%w-_]+%.googlevideo%.com/.+]]
 
 	-- Google Translate Api, Needs an api key.
 	simple [[translate.google.com]],

--- a/lua/autorun/webaudio.lua
+++ b/lua/autorun/webaudio.lua
@@ -522,7 +522,7 @@ local registers = { ["pattern"] = pattern, ["simple"] = simple }
 
 local Whitelist = {
 	-- Soundcloud
-	pattern [[%w+%.sndcdn%.com/.+]],
+	pattern [[[%w-_]+%.sndcdn%.com/.+]],
 
 	-- Google Translate Api, Needs an api key.
 	simple [[translate.google.com]],

--- a/lua/autorun/webaudio.lua
+++ b/lua/autorun/webaudio.lua
@@ -523,12 +523,12 @@ local registers = { ["pattern"] = pattern, ["simple"] = simple }
 local Whitelist = {
 	-- Soundcloud
 	pattern [[[%w-_]+%.sndcdn%.com/.+]],
-	
+
 	-- Bandcamp
-	pattern [[[%w-_]+%.bcbits%.com/.+]]
-	
+	pattern [[[%w-_]+%.bcbits%.com/.+]],
+
 	-- Google Video (used by Youtube)
-	pattern [[[%w-_]+%.googlevideo%.com/.+]]
+	pattern [[[%w-_]+%.googlevideo%.com/.+]],
 
 	-- Google Translate Api, Needs an api key.
 	simple [[translate.google.com]],


### PR DESCRIPTION
These domains would be nice to have on the default whitelist.

- `[%w-_]+%.googlevideo%.com/.+` Youtube hosts audio here
- `[%w-_]+%.sndcdn%.com/.+` Soundcloud hosts audio here (this was already on the whitelist but the pattern was missing - and _)
- `[%w-_]+%.bcbits%.com/.+` Bandcamp hosts audio here