### PR TITLE
Disable webaudio whitelist and add pls files to blacklisted filetypes

### DIFF
--- a/lua/autorun/webaudio.lua
+++ b/lua/autorun/webaudio.lua
@@ -68,7 +68,6 @@ end
 -- SERVER
 local WAAdminOnly = CreateConVar("wa_admin_only", "0", FCVAR_REPLICATED, "Whether creation of WebAudio objects should be limited to admins. 0 for everyone, 1 for admins, 2 for superadmins. wa_enable_sv takes precedence over this", 0, 2)
 local WASCCompat = CreateConVar("wa_sc_compat", "0", FCVAR_ARCHIVE, "Whether streamcore-compatible functions should be generated for E2.", 0, 1)
-local WACheckFileContent = CreateConVar("wa_sc_checkfilecontent", "1", FCVAR_REPLICATED, "Do NOT disable this unless you have other security measures in place, disabling this allows bypassing the whitelist. Whether webaudio should check the content of streams before playing", 0, 1)
 
 -- Max in total is ~1023 from ID_LEN writing a 10 bit uint. Assuming ~30 players max using webaudio, can only give ~30.
 local WAMaxStreamsPerUser = CreateConVar("wa_stream_max", "5", FCVAR_REPLICATED, "Max number of streams a player can have at once.", 1, 30)
@@ -774,7 +773,6 @@ WebAudio.Common = {
 	WAAdminOnly = WAAdminOnly,
 	WAMaxStreamsPerUser = WAMaxStreamsPerUser,
 	WASCCompat = WASCCompat,
-	WACheckFileContent = WACheckFileContent,
 
 	-- Shared
 	WAEnabled = WAEnabled,

--- a/lua/autorun/webaudio.lua
+++ b/lua/autorun/webaudio.lua
@@ -68,6 +68,7 @@ end
 -- SERVER
 local WAAdminOnly = CreateConVar("wa_admin_only", "0", FCVAR_REPLICATED, "Whether creation of WebAudio objects should be limited to admins. 0 for everyone, 1 for admins, 2 for superadmins. wa_enable_sv takes precedence over this", 0, 2)
 local WASCCompat = CreateConVar("wa_sc_compat", "0", FCVAR_ARCHIVE, "Whether streamcore-compatible functions should be generated for E2.", 0, 1)
+local WACheckFileContent = CreateConVar("wa_sc_checkfilecontent", "1", FCVAR_REPLICATED, "Do NOT disable this unless you have other security measures in place, disabling this allows bypassing the whitelist. Whether webaudio should check the content of streams before playing", 0, 1)
 
 -- Max in total is ~1023 from ID_LEN writing a 10 bit uint. Assuming ~30 players max using webaudio, can only give ~30.
 local WAMaxStreamsPerUser = CreateConVar("wa_stream_max", "5", FCVAR_REPLICATED, "Max number of streams a player can have at once.", 1, 30)
@@ -681,6 +682,9 @@ local function isWhitelistedURL(url)
 	if not isstring(url) then return false end
 	url = url:Trim()
 
+	local isWhitelisted = hook.Run("WA_IsWhitelistedURL", url)
+	if isWhitelisted ~= nil then return isWhitelisted end
+
 	local relative = url:match("^https?://www%.(.*)") or url:match("^https?://(.*)")
 	if not relative then return false end
 
@@ -770,6 +774,7 @@ WebAudio.Common = {
 	WAAdminOnly = WAAdminOnly,
 	WAMaxStreamsPerUser = WAMaxStreamsPerUser,
 	WASCCompat = WASCCompat,
+	WACheckFileContent = WACheckFileContent,
 
 	-- Shared
 	WAEnabled = WAEnabled,

--- a/lua/webaudio/receiver.lua
+++ b/lua/webaudio/receiver.lua
@@ -95,17 +95,16 @@ end)
 ---@param onError fun(err: string)
 local function checkStreamContents(url, onSuccess, onError)
     if hook.Run("WA_ShouldCheckStreamContent", url) == false then
-        onSuccess()
-        return
+        return onSuccess()
     end
 
 	http.Fetch(url, function(body, _, _)
 		if body:find("#EXTM3U", 1, true) then
-            onError("Cannot create stream with unwhitelisted file format (m3u)")
+            return onError("Cannot create stream with unwhitelisted file format (m3u)")
 		end
 
 		if body:find("[playlist]", 1, true) then
-			onError("Cannot create stream with unwhitelisted file format (pls)")
+			return onError("Cannot create stream with unwhitelisted file format (pls)")
 		end
 
         onSuccess()

--- a/lua/webaudio/receiver.lua
+++ b/lua/webaudio/receiver.lua
@@ -94,7 +94,7 @@ end)
 ---@param onSuccess fun()
 ---@param onError fun(err: string)
 local function checkStreamContents(url, onSuccess, onError)
-    if not WebAudio.Common.WACheckFileContent:GetBool() then
+    if hook.Run("WA_ShouldCheckFileContent", url) == false then
         onSuccess()
         return
     end

--- a/lua/webaudio/receiver.lua
+++ b/lua/webaudio/receiver.lua
@@ -94,23 +94,23 @@ end)
 ---@param onSuccess fun()
 ---@param onError fun(err: string)
 local function checkStreamContents(url, onSuccess, onError)
-    if hook.Run("WA_ShouldCheckStreamContent", url) == false then
-        return onSuccess()
+	if hook.Run("WA_ShouldCheckStreamContent", url) == false then
+		return onSuccess()
     end
 
 	http.Fetch(url, function(body, _, _)
 		if body:find("#EXTM3U", 1, true) then
-            return onError("Cannot create stream with unwhitelisted file format (m3u)")
+			return onError("Cannot create stream with unwhitelisted file format (m3u)")
 		end
 
 		if body:find("[playlist]", 1, true) then
 			return onError("Cannot create stream with unwhitelisted file format (pls)")
 		end
 
-        onSuccess()
-    end, function(err)
-        onError("HTTP error:" ..err)
-    end)
+		onSuccess()
+	end, function(err)
+		onError("HTTP error:" ..err)
+	end)
 end
 
 net.Receive("wa_create", function(len)

--- a/lua/webaudio/receiver.lua
+++ b/lua/webaudio/receiver.lua
@@ -227,7 +227,7 @@ net.Receive("wa_create", function(len)
 		end)
 	end, function(err)
 		streamFailed()
-		return warn("Error when creating WebAudio object, User %s(%s), Error: %s", owner:Nick(), owner:SteamID64() or "multirun", err)
+		return warn("Error when creating WebAudio object with id: %s, User %s(%s), Error: %s", id, owner:Nick(), owner:SteamID64() or "multirun", err)
 	end)
 
 	WebAudio.new(url, owner, nil, id) -- Register object

--- a/lua/webaudio/receiver.lua
+++ b/lua/webaudio/receiver.lua
@@ -94,7 +94,7 @@ end)
 ---@param onSuccess fun()
 ---@param onError fun(err: string)
 local function checkStreamContents(url, onSuccess, onError)
-    if hook.Run("WA_ShouldCheckFileContent", url) == false then
+    if hook.Run("WA_ShouldCheckStreamContent", url) == false then
         onSuccess()
         return
     end
@@ -102,6 +102,10 @@ local function checkStreamContents(url, onSuccess, onError)
 	http.Fetch(url, function(body, _, _)
 		if body:find("#EXTM3U", 1, true) then
             onError("Cannot create stream with unwhitelisted file format (m3u)")
+		end
+
+		if body:find("[playlist]", 1, true) then
+			onError("Cannot create stream with unwhitelisted file format (pls)")
 		end
 
         onSuccess()

--- a/lua/webaudio/receiver.lua
+++ b/lua/webaudio/receiver.lua
@@ -96,7 +96,7 @@ end)
 local function checkStreamContents(url, onSuccess, onError)
 	if hook.Run("WA_ShouldCheckStreamContent", url) == false then
 		return onSuccess()
-    end
+	end
 
 	http.Fetch(url, function(body, _, _)
 		if body:find("#EXTM3U", 1, true) then
@@ -109,7 +109,7 @@ local function checkStreamContents(url, onSuccess, onError)
 
 		onSuccess()
 	end, function(err)
-		onError("HTTP error:" ..err)
+		onError("HTTP error:" .. err)
 	end)
 end
 


### PR DESCRIPTION
- Add hook for checking whitelisted URLs
- Add hook to disable stream content checking
- Check for PLS files, PLS files can also be used to bypass the whitelist similar to M3U
