### PR TITLE
Add api.onedrive.com to webaudio default whitelist

### DIFF
--- a/lua/autorun/webaudio.lua
+++ b/lua/autorun/webaudio.lua
@@ -566,7 +566,8 @@ local Whitelist = {
 
 	-- Onedrive
 	simple [[onedrive.live.com/redir]],
-
+	simple [[api.onedrive.com]]
+	
 	-- ytdl host. Requires 2d mode which we currently don't support.
 	simple [[youtubedl.mattjeanes.com]],
 

--- a/lua/autorun/webaudio.lua
+++ b/lua/autorun/webaudio.lua
@@ -567,7 +567,7 @@ local Whitelist = {
 	-- Onedrive
 	simple [[onedrive.live.com/redir]],
 	simple [[api.onedrive.com]],
-	
+
 	-- ytdl host. Requires 2d mode which we currently don't support.
 	simple [[youtubedl.mattjeanes.com]],
 

--- a/lua/autorun/webaudio.lua
+++ b/lua/autorun/webaudio.lua
@@ -566,7 +566,7 @@ local Whitelist = {
 
 	-- Onedrive
 	simple [[onedrive.live.com/redir]],
-	simple [[api.onedrive.com]]
+	simple [[api.onedrive.com]],
 	
 	-- ytdl host. Requires 2d mode which we currently don't support.
 	simple [[youtubedl.mattjeanes.com]],


### PR DESCRIPTION
Another way to have direct links to onedrive content that pac users often use.

Example link:
https://api.onedrive.com/v1.0/shares/u!aHR0cHM6Ly8xZHJ2Lm1zL3UvcyFBcmFSdWJSdXY0SlM5azRMN3F4T1R6YkNYRkd0P2U9a093U3Az/root/content

Pac3 documentation containing a convenient converter for onedrive indirect links to api.onedrive.com direct links:
https://wiki.pac3.info/tutorial/hosting